### PR TITLE
Added parsing for route upload_dir

### DIFF
--- a/src/configuration/Parser.cpp
+++ b/src/configuration/Parser.cpp
@@ -320,6 +320,13 @@ Route Parser::parseRoute() {
 				break;
 			}
 
+			case TOKEN_UPLOAD_DIR:
+				expect(TOKEN_UPLOAD_DIR);
+				route.setUploadDir(_currentToken.value);
+				expect(TOKEN_STRING);
+				expect(TOKEN_SEMICOLON);
+				break;
+
 			case TOKEN_RETURN: {
 				expect(TOKEN_RETURN);
 


### PR DESCRIPTION
Wasn't sure whether or not uploadDir had to be removed from the Server parsing, so it can now just be used in both server and route